### PR TITLE
Make lambda_event.py python 2.6 compatible

### DIFF
--- a/library/lambda_event.py
+++ b/library/lambda_event.py
@@ -824,7 +824,7 @@ def main():
 
     validate_params(module, aws)
 
-    this_module_function = getattr(this_module, 'lambda_event_{}'.format(module.params['event_source'].lower()))
+    this_module_function = getattr(this_module, 'lambda_event_{0}'.format(module.params['event_source'].lower()))
 
     results = this_module_function(module, aws)
 


### PR DESCRIPTION
"Changed in version 2.7: The positional argument specifiers can be omitted, so '{} {}' is equivalent to '{0} {1}'."